### PR TITLE
[UPG][3764151] school_lunch: enable custom 'res_config' view

### DIFF
--- a/school_lunch/migrations/17.0.1.0.0/pre-migrate.py
+++ b/school_lunch/migrations/17.0.1.0.0/pre-migrate.py
@@ -1,5 +1,6 @@
-from odoo.upgrade import util
+from odoo.upgrade import custom_util, util
 
 
 def migrate(cr, version):
     util.remove_module(cr, "school_event")
+    custom_util.activate_views(cr, "school_lunch.res_config_settings_school_lunch_form")

--- a/school_lunch/views/res_config_settings_views.xml
+++ b/school_lunch/views/res_config_settings_views.xml
@@ -64,7 +64,7 @@
         <field name="view_id" ref="res_config_settings_school_lunch_form"/>
         <field name="view_mode">form</field>
         <field name="target">inline</field>
-        <field name="context">{'module' : 'lunch', 'bin_size': False}</field>
+        <field name="context">{'module' : 'school_lunch', 'bin_size': False}</field>
     </record>
     <menuitem
         name="Settings"


### PR DESCRIPTION
### Description

The custom `res_config_settings_school_lunch_form` view was disabled during the Standard migration. Since the view has already been upgraded, it is only re-activated.
I'm also fixing a `context` field that was not working as expected.

Link to task: [#3764151](https://www.odoo.com/web#model=project.task&id=3764151)

### All Submissions:

* [ ] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [ ] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [ ] I have used pre-commit
* [ ] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [ ] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [ ] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 

### Maintenance reminders:

* Always bump the version of the manifest on the affected modules.
* Notify the developer responsible for the initial development task (when this is relevant).
