### PR TITLE
[UPG][3927571] school_lunch: fix menu button order

### DIFF
--- a/school_lunch/views/templates.xml
+++ b/school_lunch/views/templates.xml
@@ -27,16 +27,6 @@
                         </t>
                         <t t-esc="date.strftime('%Y')"/>
                         <a
-                            t-attf-href="/menu/#{int((date+dmonth).timestamp())}"
-                            class="btn btn-outline-secondary float-right"
-                        >
-                            <i class="fa fa-arrow-right"/>
-                            <t t-call="school_lunch.website_month_display">
-                                <t t-set="month" t-value="(date+dmonth).month"/>
-                            </t>
-                            <t t-esc="(date+dmonth).strftime('%Y')"/>
-                        </a>
-                        <a
                             t-attf-href="/menu/#{int((date-dmonth).timestamp())}"
                             class="btn btn-outline-secondary float-right"
                         >
@@ -45,6 +35,16 @@
                                 <t t-set="month" t-value="(date-dmonth).month"/>
                             </t>
                             <t t-esc="(date-dmonth).strftime('%Y')"/>
+                        </a>
+                        <a
+                            t-attf-href="/menu/#{int((date+dmonth).timestamp())}"
+                            class="btn btn-outline-secondary float-right"
+                        >
+                            <i class="fa fa-arrow-right"/>
+                            <t t-call="school_lunch.website_month_display">
+                                <t t-set="month" t-value="(date+dmonth).month"/>
+                            </t>
+                            <t t-esc="(date+dmonth).strftime('%Y')"/>
                         </a>
                     </h1>
                     <div style="clear: both"/>
@@ -66,16 +66,6 @@
                                 Order Now <i class="fa fa-arrow-right"/>
                         </a>
                         <a
-                            t-attf-href="/menu/agenda/#{int((date+dmonth).timestamp())}"
-                            class="btn btn-outline-secondary float-right"
-                        >
-                            <i class="fa fa-arrow-right"/>
-                            <t t-call="school_lunch.website_month_display">
-                                <t t-set="month" t-value="(date+dmonth).month"/>
-                            </t>
-                            <t t-esc="(date+dmonth).strftime('%Y')"/>
-                        </a>
-                        <a
                             t-attf-href="/menu/agenda/#{int((date-dmonth).timestamp())}"
                             class="btn btn-outline-secondary float-right"
                         >
@@ -84,6 +74,16 @@
                                 <t t-set="month" t-value="(date-dmonth).month"/>
                             </t>
                             <t t-esc="(date-dmonth).strftime('%Y')"/>
+                        </a>
+                        <a
+                            t-attf-href="/menu/agenda/#{int((date+dmonth).timestamp())}"
+                            class="btn btn-outline-secondary float-right"
+                        >
+                            <i class="fa fa-arrow-right"/>
+                            <t t-call="school_lunch.website_month_display">
+                                <t t-set="month" t-value="(date+dmonth).month"/>
+                            </t>
+                            <t t-esc="(date+dmonth).strftime('%Y')"/>
                         </a>
                     </h1>
                     <t t-set="number" t-value="0"/>


### PR DESCRIPTION
### Description

- The menu buttons were badly ordered (next -> previous) instead of (previous -> next). Their XML elements are reordered.
This happens twice in the `templates.xml` file.

Link to task: [#3927571](https://www.odoo.com/web#model=project.task&id=3927571)

![image](https://github.com/odoo-ps/psbe-school/assets/100482501/f130c772-5c54-4389-9ce9-2ea6c4143ca3)

### All Submissions:

* [x] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [x] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [x] I have used pre-commit
* [x] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [ ] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [x] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 

### Maintenance reminders:

* Always bump the version of the manifest on the affected modules.
* Notify the developer responsible for the initial development task (when this is relevant).
