### PR TITLE
[UPG][3927659] /: reset mail template

### DIFF
--- a/school_lunch/migrations/17.0.1.0.0/end--migrate-mail.py
+++ b/school_lunch/migrations/17.0.1.0.0/end--migrate-mail.py
@@ -1,0 +1,11 @@
+from odoo.upgrade import util
+
+
+def migrate(cr, _):
+
+    mail_template_xml_ids = [
+        "sale.mail_template_sale_confirmation",
+    ]
+
+    for mail_template in mail_template_xml_ids:
+        util.update_record_from_xml(cr, mail_template, reset_translations=True)


### PR DESCRIPTION
### Description

The `sale.mail_template_sale_confirmation` had been edited by the customer, but didn't add any text elements. Instead, the French translation had many `t-if` and `t-elif` elements that were not properly closed, making the template raise errors. Resetting the translations (hence the arch of the template) is enough to fix this. 

Link to task: [#3927659](https://www.odoo.com/web#model=project.task&id=3927659)

### All Submissions:

* [x] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [x] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [x] I have used pre-commit
* [x] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [x] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [x] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 

### Maintenance reminders:

* Always bump the version of the manifest on the affected modules.
* Notify the developer responsible for the initial development task (when this is relevant).
