### PR TITLE
[FIX] school_lunch: add guest reservation

### DIFF
--- a/school_lunch/__manifest__.py
+++ b/school_lunch/__manifest__.py
@@ -12,7 +12,7 @@
     # Check https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     "category": "Lunch",
-    "version": "17.0.1.0.4",
+    "version": "17.0.1.0.5",
     # any module necessary for this one to work correctly
     "depends": ["website_sale_loyalty"],
     "license": "OEEL-1",

--- a/school_lunch/data/school_lunch.xml
+++ b/school_lunch/data/school_lunch.xml
@@ -52,5 +52,16 @@
             <field name="name">M3</field>
         </record>
 
+        <!-- Guests -->
+
+        <record id="class_name_guest" model="school_lunch.class_name">
+            <field name="class_type">3</field>
+            <field name="name">Invité</field>
+        </record>
+        <record id="kid_guest" model="school_lunch.kid">
+            <field name="firstname">Invité</field>
+            <field name="lastname">Externe</field>
+            <field name="class_id" ref="school_lunch.class_name_guest"/>
+        </record>
     </data>
 </odoo>

--- a/school_lunch/migrations/17.0.1.0.5/pre-10-migrate.py
+++ b/school_lunch/migrations/17.0.1.0.5/pre-10-migrate.py
@@ -1,0 +1,5 @@
+from odoo.upgrade import util
+
+
+def migrate(cr, _):
+    util.ensure_xmlid_match_record(cr, "school_lunch.class_name_guest", "school_lunch.class_name", {"name": "Invité"})

--- a/school_lunch/models/school_lunch.py
+++ b/school_lunch/models/school_lunch.py
@@ -131,8 +131,15 @@ class Order(models.Model):
                 "off": 4,
             }.get(order.meal_type, 1)
 
-    def order_create(self, data):
-        pass
+    @api.model_create_multi
+    def create(self, vals_list):
+        orders = super().create(vals_list)
+        guest_id = self.env.ref("school_lunch.kid_guest").id
+        for order in orders:
+            if order.kid_id.id == guest_id:
+                order.state = "confirmed"
+        orders._compute_date_end_gantt()
+        return orders
 
 
 class ClassName(models.Model):


### PR DESCRIPTION
### Description

- In the current code, it is impossible to add a meal for a guest (res.partner that is not a 'school_lunch.kid'). This is fixed here by adding in the custom data a special `guest` record.

This is not coming from a task, as this is a result of a conversation with the BA. No ID is added.
The code has been tested on a dev branch on SH, and on a duplicate of the production DB.
 
### All Submissions:

* [x] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [x] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [x] I have used pre-commit
* [x] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [x] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [x] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 

### Maintenance reminders:

* Always bump the version of the manifest on the affected modules.
* Notify the developer responsible for the initial development task (when this is relevant).
